### PR TITLE
Replace _finite with std::isfinite

### DIFF
--- a/Descent3/Player.cpp
+++ b/Descent3/Player.cpp
@@ -1083,6 +1083,8 @@
  *
  * $NoKeywords: $
  */
+#include <cmath>
+
 
 #include <misc/pserror.h>
 #include "player.h"
@@ -3295,9 +3297,9 @@ float MoveDeathCam(int slot, vector *vec, float distance) {
     fq.ignore_obj_list = NULL;
     fq.flags = 0;
 
-    ASSERT(_finite(next_vec.x) != 0);
-    ASSERT(_finite(next_vec.y) != 0);
-    ASSERT(_finite(next_vec.z) != 0);
+    ASSERT(std::isfinite(next_vec.x));
+    ASSERT(std::isfinite(next_vec.y));
+    ASSERT(std::isfinite(next_vec.z));
 
     fvi_FindIntersection(&fq, &hit_data);
 

--- a/legacy/powerball/powerball.cpp
+++ b/legacy/powerball/powerball.cpp
@@ -16,6 +16,8 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <cmath>
+
 #include "windows.h"
 #include "gamedll_header.h"
 #include <cstring>
@@ -1241,18 +1243,18 @@ void bump_two_objects(object *object0, vector *rotvel, vector *velocity, vector 
 	object *t = NULL;
 	object *other = NULL;
 
-	ASSERT(_finite(rotvel->x) != 0);
-	ASSERT(_finite(rotvel->y) != 0);
-	ASSERT(_finite(rotvel->z) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.rotvel.x) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.rotvel.y) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.rotvel.z) != 0);
-	ASSERT(_finite(velocity->x) != 0);
-	ASSERT(_finite(velocity->y) != 0);
-	ASSERT(_finite(velocity->z) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.velocity.x) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.velocity.y) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.velocity.z) != 0);
+	ASSERT(std::isfinite(rotvel->x));
+	ASSERT(std::isfinite(rotvel->y));
+	ASSERT(std::isfinite(rotvel->z));
+	ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.x));
+	ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.y));
+	ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.z));
+	ASSERT(std::isfinite(velocity->x));
+	ASSERT(std::isfinite(velocity->y));
+	ASSERT(std::isfinite(velocity->z));
+	ASSERT(std::isfinite(object0->mtype.phys_info.velocity.x));
+	ASSERT(std::isfinite(object0->mtype.phys_info.velocity.y));
+	ASSERT(std::isfinite(object0->mtype.phys_info.velocity.z));
 
 	vector r1 = *collision_point - object0->pos;
 	vector r2 = *collision_point - (*pos);
@@ -1368,10 +1370,10 @@ void bump_two_objects(object *object0, vector *rotvel, vector *velocity, vector 
 	//change the player's rotational velocity
 	object0->mtype.phys_info.rotvel += (txx1*object0->orient) * rotscale1;
 	
-	ASSERT(_finite(object0->mtype.phys_info.rotvel.x) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.rotvel.y) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.rotvel.z) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.velocity.x) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.velocity.y) != 0);
-	ASSERT(_finite(object0->mtype.phys_info.velocity.z) != 0);
+	ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.x));
+	ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.y));
+	ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.z));
+	ASSERT(std::isfinite(object0->mtype.phys_info.velocity.x));
+	ASSERT(std::isfinite(object0->mtype.phys_info.velocity.y));
+	ASSERT(std::isfinite(object0->mtype.phys_info.velocity.z));
 }

--- a/linux/linux_fix.h
+++ b/linux/linux_fix.h
@@ -1,5 +1,5 @@
 /*
-* Descent 3 
+* Descent 3
 * Copyright (C) 2024 Parallax Software
 *
 * This program is free software: you can redistribute it and/or modify
@@ -45,10 +45,4 @@ char *strupr(char *string);
 #define stricmp(a, b) strcasecmp(a, b)
 #define strnicmp(a, b, c) strncasecmp(a, b, c)
 #define _chmod(a, b) chmod(a, b)
-#if defined(__aarch64__)
-#define _finite(a) isfinite(a)
-#else
-#define _finite(a) finite(a)
-#endif
-
 #endif

--- a/netgames/monsterball/monsterball.cpp
+++ b/netgames/monsterball/monsterball.cpp
@@ -162,6 +162,8 @@
  * $NoKeywords: $
  */
 
+#include <cmath>
+
 #include "gamedll_header.h"
 #include "idmfc.h"
 #include "monsterball.h"
@@ -1926,18 +1928,18 @@ void bump_object(object *object0, vector *rotvel, vector *velocity, vector *pos,
   object *t = NULL;
   object *other = NULL;
 
-  ASSERT(_finite(rotvel->x) != 0);
-  ASSERT(_finite(rotvel->y) != 0);
-  ASSERT(_finite(rotvel->z) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.x) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.y) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.z) != 0);
-  ASSERT(_finite(velocity->x) != 0);
-  ASSERT(_finite(velocity->y) != 0);
-  ASSERT(_finite(velocity->z) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.x) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.y) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.z) != 0);
+  ASSERT(std::isfinite(rotvel->x));
+  ASSERT(std::isfinite(rotvel->y));
+  ASSERT(std::isfinite(rotvel->z));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.x));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.y));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.z));
+  ASSERT(std::isfinite(velocity->x));
+  ASSERT(std::isfinite(velocity->y));
+  ASSERT(std::isfinite(velocity->z));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.x));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.y));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.z));
 
   vector r1 = *collision_point - object0->pos;
   vector r2 = *collision_point - (*pos);
@@ -2057,12 +2059,12 @@ void bump_object(object *object0, vector *rotvel, vector *velocity, vector *pos,
   // change the player's rotational velocity
   object0->mtype.phys_info.rotvel += (txx1 * object0->orient) * rotscale1;
 
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.x) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.y) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.z) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.x) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.y) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.z) != 0);
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.x));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.y));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.z));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.x));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.y));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.z));
 }
 
 bool ValidateOwner(int *pnum, object **obj) {

--- a/physics/collide.cpp
+++ b/physics/collide.cpp
@@ -826,7 +826,7 @@
  *
  * $NoKeywords: $
  */
-
+#include <cmath>
 #include <cstdlib>
 #include <cstdio>
 
@@ -1833,12 +1833,12 @@ void ConvertAxisAmountToEuler(vector *n, float *w, vector *e) {
 }
 
 void bump_obj_against_fixed(object *obj, vector *collision_point, vector *collision_normal) {
-  ASSERT(_finite(obj->mtype.phys_info.rotvel.x) != 0);
-  ASSERT(_finite(obj->mtype.phys_info.rotvel.y) != 0);
-  ASSERT(_finite(obj->mtype.phys_info.rotvel.z) != 0);
-  ASSERT(_finite(obj->mtype.phys_info.velocity.x) != 0);
-  ASSERT(_finite(obj->mtype.phys_info.velocity.y) != 0);
-  ASSERT(_finite(obj->mtype.phys_info.velocity.z) != 0);
+  ASSERT(std::isfinite(obj->mtype.phys_info.rotvel.x));
+  ASSERT(std::isfinite(obj->mtype.phys_info.rotvel.y));
+  ASSERT(std::isfinite(obj->mtype.phys_info.rotvel.z));
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.x));
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.y));
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.z));
 
   if (!IsOKToApplyForce(obj))
     return;
@@ -1916,12 +1916,12 @@ void bump_obj_against_fixed(object *obj, vector *collision_point, vector *collis
 
   obj->mtype.phys_info.rotvel += (txx1 * obj->orient);
 
-  ASSERT(_finite(obj->mtype.phys_info.rotvel.x) != 0);
-  ASSERT(_finite(obj->mtype.phys_info.rotvel.y) != 0);
-  ASSERT(_finite(obj->mtype.phys_info.rotvel.z) != 0);
-  ASSERT(_finite(obj->mtype.phys_info.velocity.x) != 0);
-  ASSERT(_finite(obj->mtype.phys_info.velocity.y) != 0);
-  ASSERT(_finite(obj->mtype.phys_info.velocity.z) != 0);
+  ASSERT(std::isfinite(obj->mtype.phys_info.rotvel.x));
+  ASSERT(std::isfinite(obj->mtype.phys_info.rotvel.y));
+  ASSERT(std::isfinite(obj->mtype.phys_info.rotvel.z));
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.x));
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.y));
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.z));
 
   // hack rotvel
   /*	vector v = obj->mtype.phys_info.velocity;
@@ -2082,18 +2082,18 @@ void bump_two_objects(object *object0, object *object1, vector *collision_point,
   //	vector r_vel = object0->mtype.phys_info.velocity - object1->mtype.phys_info.velocity;
   // Add this back
 
-  ASSERT(_finite(object1->mtype.phys_info.rotvel.x) != 0);
-  ASSERT(_finite(object1->mtype.phys_info.rotvel.y) != 0);
-  ASSERT(_finite(object1->mtype.phys_info.rotvel.z) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.x) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.y) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.z) != 0);
-  ASSERT(_finite(object1->mtype.phys_info.velocity.x) != 0);
-  ASSERT(_finite(object1->mtype.phys_info.velocity.y) != 0);
-  ASSERT(_finite(object1->mtype.phys_info.velocity.z) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.x) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.y) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.z) != 0);
+  ASSERT(std::isfinite(object1->mtype.phys_info.rotvel.x));
+  ASSERT(std::isfinite(object1->mtype.phys_info.rotvel.y));
+  ASSERT(std::isfinite(object1->mtype.phys_info.rotvel.z));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.x));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.y));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.z));
+  ASSERT(std::isfinite(object1->mtype.phys_info.velocity.x));
+  ASSERT(std::isfinite(object1->mtype.phys_info.velocity.y));
+  ASSERT(std::isfinite(object1->mtype.phys_info.velocity.z));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.x));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.y));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.z));
 
   vector r1 = *collision_point - object0->pos;
   vector r2 = *collision_point - object1->pos;
@@ -2237,18 +2237,18 @@ void bump_two_objects(object *object0, object *object1, vector *collision_point,
   if (f_force_2)
     object1->mtype.phys_info.rotvel += (txx2 * object1->orient) * rotscale2;
 
-  ASSERT(_finite(object1->mtype.phys_info.rotvel.x) != 0);
-  ASSERT(_finite(object1->mtype.phys_info.rotvel.y) != 0);
-  ASSERT(_finite(object1->mtype.phys_info.rotvel.z) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.x) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.y) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.rotvel.z) != 0);
-  ASSERT(_finite(object1->mtype.phys_info.velocity.x) != 0);
-  ASSERT(_finite(object1->mtype.phys_info.velocity.y) != 0);
-  ASSERT(_finite(object1->mtype.phys_info.velocity.z) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.x) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.y) != 0);
-  ASSERT(_finite(object0->mtype.phys_info.velocity.z) != 0);
+  ASSERT(std::isfinite(object1->mtype.phys_info.rotvel.x));
+  ASSERT(std::isfinite(object1->mtype.phys_info.rotvel.y));
+  ASSERT(std::isfinite(object1->mtype.phys_info.rotvel.z));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.x));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.y));
+  ASSERT(std::isfinite(object0->mtype.phys_info.rotvel.z));
+  ASSERT(std::isfinite(object1->mtype.phys_info.velocity.x));
+  ASSERT(std::isfinite(object1->mtype.phys_info.velocity.y));
+  ASSERT(std::isfinite(object1->mtype.phys_info.velocity.z));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.x));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.y));
+  ASSERT(std::isfinite(object0->mtype.phys_info.velocity.z));
 
   // Do ForceFeedback stuff for moving objects
   //-----------------------------------------

--- a/physics/findintersection.cpp
+++ b/physics/findintersection.cpp
@@ -2666,9 +2666,9 @@ int fvi_FindIntersection(fvi_query *fq, fvi_info *hit_data, bool no_subdivision)
 
   ASSERT(fq != NULL && hit_data != NULL);
 
-  ASSERT(_finite(fq->p1->x) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
-  ASSERT(_finite(fq->p1->y) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
-  ASSERT(_finite(fq->p1->z) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(fq->p1->x)); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(fq->p1->y)); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(fq->p1->z)); // Caller wants to go to infinity!  -- Not FVI's fault.
 
   fvi_movement_delta = *fq->p1 - *fq->p0;
 

--- a/physics/physics.cpp
+++ b/physics/physics.cpp
@@ -15,7 +15,7 @@
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
+#include <cmath>
 #include <cstdlib>
 #include <memory.h>
 
@@ -780,9 +780,9 @@ void do_physics_sim(object *obj) {
 
   DebugBlockPrint("P ");
 
-  ASSERT(_finite(obj->mtype.phys_info.velocity.x) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
-  ASSERT(_finite(obj->mtype.phys_info.velocity.y) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
-  ASSERT(_finite(obj->mtype.phys_info.velocity.z) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.x)); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.y)); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.z)); // Caller wants to go to infinity!  -- Not FVI's fault.
 
 #ifdef _DEBUG
   if (!Game_do_flying_sim) {
@@ -1869,9 +1869,9 @@ end_of_sim:
 
   AttachUpdateSubObjects(obj);
 
-  ASSERT(_finite(obj->mtype.phys_info.velocity.x) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
-  ASSERT(_finite(obj->mtype.phys_info.velocity.y) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
-  ASSERT(_finite(obj->mtype.phys_info.velocity.z) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.x)); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.y)); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.z)); // Caller wants to go to infinity!  -- Not FVI's fault.
 
   obj->last_pos = init_pos;
   return;
@@ -2293,9 +2293,9 @@ void do_walking_sim(object *obj) {
   ASSERT(obj->type != OBJ_NONE);
   ASSERT(obj->movement_type == MT_WALKING);
   ASSERT(!(obj->mtype.phys_info.flags & PF_USES_THRUST) || obj->mtype.phys_info.drag != 0.0);
-  ASSERT(_finite(obj->mtype.phys_info.velocity.x) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
-  ASSERT(_finite(obj->mtype.phys_info.velocity.y) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
-  ASSERT(_finite(obj->mtype.phys_info.velocity.z) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.x)); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.y)); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.z)); // Caller wants to go to infinity!  -- Not FVI's fault.
 
   DebugBlockPrint("PW");
 
@@ -2867,9 +2867,9 @@ void do_walking_sim(object *obj) {
 end_of_sim:
   AttachUpdateSubObjects(obj);
 
-  ASSERT(_finite(obj->mtype.phys_info.velocity.x) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
-  ASSERT(_finite(obj->mtype.phys_info.velocity.y) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
-  ASSERT(_finite(obj->mtype.phys_info.velocity.z) != 0); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.x)); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.y)); // Caller wants to go to infinity!  -- Not FVI's fault.
+  ASSERT(std::isfinite(obj->mtype.phys_info.velocity.z)); // Caller wants to go to infinity!  -- Not FVI's fault.
 
   obj->last_pos = init_pos;
   return;


### PR DESCRIPTION
## Pull Request Type
- [x] Runtime changes
  - [x] Other changes

### Description
[`std::isfinite`](https://en.cppreference.com/w/cpp/numeric/math/isfinite) is a drop in replacement for [`_finite`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/finite-finitef?view=msvc-170) that is multiplatform which means the definition in `linux_fix.h` is no longer required.

### Checklist
<!-- Please review the following checklist before submitting your pull request -->

- [x] I have tested my changes locally and verified that they work as intended.
- [x] I have documented any new or modified functionality.
- [x] I have reviewed the changes to ensure they do not introduce any unnecessary complexity or duplicate code.
- [x] I understand that by submitting this pull request, I am agreeing to license my contributions under the project's license.
